### PR TITLE
Re-add support for Python 3.7 and 3.8.

### DIFF
--- a/ass_tag_parser/__init__.py
+++ b/ass_tag_parser/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .ass_composer import compose_ass
 from .ass_parser import ass_to_plaintext, parse_ass
 from .ass_struct import *

--- a/ass_tag_parser/ass_composer.py
+++ b/ass_tag_parser/ass_composer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 
 from ass_tag_parser.ass_struct import (

--- a/ass_tag_parser/ass_parser.py
+++ b/ass_tag_parser/ass_parser.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
 import re
 from dataclasses import dataclass
-from functools import cache
 from typing import Any, Iterable, Optional, Union
+
+import sys
+sys_version=int(sys.version_info[1])
+if sys_version >= 9:
+    from functools import cache
+elif sys_version < 9:
+    pass
 
 from ass_tag_parser.ass_struct import (
     AssItem,
@@ -698,20 +705,38 @@ def parse_ass(text: str) -> list[AssItem]:
     return list(_parse_ass(ctx))
 
 
-@cache
-def ass_to_plaintext(text: str) -> str:
-    """Strip ASS tags from an ASS line.
+if sys_version >= 9:
+    @cache
+    def ass_to_plaintext(text: str) -> str:
+        """Strip ASS tags from an ASS line.
 
-    :param text: input ASS line
-    :return: plain text
-    """
-    try:
-        ass_line = parse_ass(text)
-    except ParseError:
-        ret = str(re.sub("{[^}]*}", "", text))
-    else:
-        ret = ""
-        for item in ass_line:
-            if isinstance(item, AssText):
-                ret += item.text
-    return ret.replace("\\h", " ").replace("\\n", " ").replace("\\N", "\n")
+        :param text: input ASS line
+        :return: plain text
+        """
+        try:
+            ass_line = parse_ass(text)
+        except ParseError:
+            ret = str(re.sub("{[^}]*}", "", text))
+        else:
+            ret = ""
+            for item in ass_line:
+                if isinstance(item, AssText):
+                    ret += item.text
+        return ret.replace("\\h", " ").replace("\\n", " ").replace("\\N", "\n")
+elif sys_version < 9:
+    def ass_to_plaintext(text: str) -> str:
+        """Strip ASS tags from an ASS line.
+
+        :param text: input ASS line
+        :return: plain text
+        """
+        try:
+            ass_line = parse_ass(text)
+        except ParseError:
+            ret = str(re.sub("{[^}]*}", "", text))
+        else:
+            ret = ""
+            for item in ass_line:
+                if isinstance(item, AssText):
+                    ret += item.text
+        return ret.replace("\\h", " ").replace("\\n", " ").replace("\\N", "\n")

--- a/ass_tag_parser/ass_struct.py
+++ b/ass_tag_parser/ass_struct.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/ass_tag_parser/common.py
+++ b/ass_tag_parser/common.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import Union
-
 
 @dataclass
 class Meta:

--- a/ass_tag_parser/draw_composer.py
+++ b/ass_tag_parser/draw_composer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Any
 
 from ass_tag_parser.common import smart_float

--- a/ass_tag_parser/draw_parser.py
+++ b/ass_tag_parser/draw_parser.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, Optional, Union, cast
+
+import sys
+sys_version=int(sys.version_info[1])
 
 from ass_tag_parser.common import Meta
 from ass_tag_parser.draw_struct import (
@@ -81,12 +85,10 @@ def _parse_draw_commands(ctx: _ParseContext) -> Iterable[AssDrawCmd]:
         elif cmd == "l":
             ret = AssDrawCmdLine(list(_read_points(ctx.io, min_count=1)))
         elif cmd == "b":
-            ret = AssDrawCmdBezier(
-                cast(
-                    tuple[AssDrawPoint, AssDrawPoint, AssDrawPoint],
-                    tuple(_read_points(ctx.io, min_count=3, max_count=3)),
-                )
-            )
+            if sys_version >= 9:
+                ret = AssDrawCmdBezier(cast(tuple[AssDrawPoint, AssDrawPoint, AssDrawPoint], tuple(_read_points(ctx.io, min_count=3, max_count=3)),))
+            elif sys_version < 9:
+                ret = AssDrawCmdBezier(cast(tuple, tuple(_read_points(ctx.io, min_count=3, max_count=3)),))
         elif cmd == "s":
             ret = AssDrawCmdSpline(
                 list(_read_points(ctx.io, min_count=3, max_count=None))

--- a/ass_tag_parser/draw_struct.py
+++ b/ass_tag_parser/draw_struct.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 

--- a/ass_tag_parser/errors.py
+++ b/ass_tag_parser/errors.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 from typing import Optional
-
 
 class BaseError(Exception):
     pass

--- a/ass_tag_parser/io.py
+++ b/ass_tag_parser/io.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
 import io
 from typing import Optional
-
 
 class MyIO:
     def __init__(


### PR DESCRIPTION
As per https://peps.python.org/pep-0563/

I certify: https://developercertificate.org/

The above changes and any subsequent changes are made under the same license as the original project which is MIT. A copy of this license is available at: https://github.com/gdiaz384/ass_tag_parser/blob/master/LICENSE.md

I have not tested the changes on Python 3.9+ as that does not relate to my use case, but the changes are unlikely to break anything.